### PR TITLE
Update Ubuntu and Debian deps to use repo.saltstack.com versions if unchanged

### DIFF
--- a/file_roots/auto_setup/auto_base_map.jinja
+++ b/file_roots/auto_setup/auto_base_map.jinja
@@ -76,6 +76,7 @@
 {% set build_salt_dir = build_homedir ~ '/salt_dir' %}
 {% set build_salt_pypi_dir = build_homedir ~ '/pypi_dir' %}
 {% set build_salt_pack_dir = build_homedir ~ '/salt_pack_dir' %}
+{% set build_salt_tmp_dir = build_homedir ~ '/salt_tmp_dir' %}
 {% set build_salt_reactor_file = '/srv/reactor/auto_pack_event.sls' %}
 {% set build_salt_reactor_conf = '/etc/salt/master.d/reactor.conf' %}
 

--- a/file_roots/auto_setup/copy_build_deps_check_repo.sls
+++ b/file_roots/auto_setup/copy_build_deps_check_repo.sls
@@ -1,0 +1,199 @@
+{% import "auto_setup/auto_base_map.jinja" as base_cfg %}
+
+## comment high-lighting
+
+{% set build_py3 = pillar.get('build_py3', False) %}
+{% if build_py3 %}
+{% set build_py_ver = 'py3' %}
+{% else %}
+{% set build_py_ver = 'py2' %}
+{% endif %}
+
+{% set build_arch = grains.get('osarch') %}
+
+## set platform
+{% if grains.get('os_family') == 'Debian' -%}
+{% set platform_pkg = 'apt' %}
+
+{% if grains.get('os') == 'Ubuntu' -%}
+{% set platform = grains.get('os')|lower -%}
+{% set os_version = grains.get('osrelease') %}
+{% set tgt_build_release = platform ~ os_version.replace('.', '') %}
+{% else %}
+{% set platform = grains.get('os_family')|lower -%}
+{% set os_version = grains.get('osmajorrelease') %}
+{% set tgt_build_release = platform ~ grains.get('osmajorrelease') %}
+{% endif %}
+
+{% elif grains.get('os_family') == 'RedHat' -%}
+{% set platform_pkg = 'yum' %}
+
+{% if grains.get('os') == 'Amazon' -%}
+{% set platform = grains.get('os')|lower -%}
+{% if build_py3 %}
+## only build Amazon Linux 2 for Py3, Amazon Linux 1 for Py2
+{% set os_version = '2' %}
+{% set tgt_build_release = 'amzn' ~ os_version %}
+{% else %}
+{% set os_version = 'latest' %}
+{% set tgt_build_release = 'amzn' %}
+{% endif %}
+{% else %}
+{% set platform = grains.get('os_family')|lower -%}
+{% set tgt_build_release = 'rhel' ~ grains.get('osmajorrelease') %}
+{% set os_version = grains.get('osmajorrelease') %}
+{% endif %}
+
+{% else %}
+{% set platform_pkg = 'Unsupported-platform-packager' -%}
+{% set platform = 'Unsupported-platform' -%}
+{% set tgt_build_release = 'Unsupported-platform' -%}
+{% endif %}
+
+{% set minion_platform = pillar.get('build_release', tgt_build_release) %}
+{% set specific_user = pillar.get('specific_name_user', 'saltstack') %}
+{% set build_dest = pillar.get('build_dest') %}
+{% set platform_name = platform|lower %}
+{% set nb_srcdir = build_dest ~ '/' ~ build_py_ver ~ '/' ~ minion_platform ~ '/' ~ build_arch %}
+
+{% set build_branch = base_cfg.build_version_dotted %}
+
+{% if base_cfg.build_specific_tag %}
+{% set nb_destdir = base_cfg.build_dsig %}
+{% else %}
+{% set nb_destdir = base_cfg.build_version ~ base_cfg.build_dsig %}
+{% endif %}
+
+## if Python 3 then override yum or apt
+{% if build_py3 %}
+{% set platform_pkg = 'py3' %}
+{% endif %}
+
+{% set repo_url = 'http://repo.saltstack.com' %}
+{% set web_compatible_dir = platform_pkg ~ '/' ~ platform_name ~ '/' ~ os_version ~ '/' ~ build_arch %}
+
+{% set nfs_server_base_dir = base_cfg.minion_mount_nfsbasedir ~ '/' ~ specific_user ~ '/' ~ web_compatible_dir %}
+
+{% set copy_repo_check_script_file = base_cfg.build_homedir ~ '/copy_deps_repo_check.sh' %}
+
+{% if platform == 'debian' or platform == 'ubuntu' %}
+## only need to perform this check for Debian or Ubuntu families
+
+
+cleanup_deps_tmpdir:
+  file.absent:
+    - name: {{base_cfg.build_salt_tmp_dir}}
+
+
+mkdir_deps_tmpdir:
+  file.directory:
+    - name: {{base_cfg.build_salt_tmp_dir}}
+    - user: {{base_cfg.build_runas}}
+    - group: {{base_cfg.build_runas}}
+    - dir_mode: 775
+    - file_mode: 644
+    - makedirs: True
+    - recurse:
+        - user
+        - group
+        - mode
+
+
+copy_repo_latest_deps:
+  cmd.run:
+    - name: |
+        wget --recursive --no-parent --no-check-certificate  --convert-links --reject index* --no-host-directories --cut-dirs=5  {{repo_url}}/{{web_compatible_dir}}/latest/
+    - cwd: {{base_cfg.build_salt_tmp_dir}}/
+    - runas: {{base_cfg.build_runas}}
+    - use_vt: True
+    - require:
+      - file: mkdir_deps_tmpdir
+
+
+remove_salt_tmp_dirs_packages:
+  cmd.run:
+    - name: |
+        rm -fR {{base_cfg.build_salt_tmp_dir}}/conf {{base_cfg.build_salt_tmp_dir}}/db {{base_cfg.build_salt_tmp_dir}}/dists {{base_cfg.build_salt_tmp_dir}}/pool
+    - require:
+      - cmd: copy_repo_latest_deps
+
+
+## now we have a copy of the latest on repo.saltstack.com
+## we need to compare to see if same in tmp dir as just built, need to give pref.
+## to version from tmp dir, but cannot do straight name replace since abc.orig.tar.gz will
+## match new abc.orig.tar.gz, hence need to check debian.tar.[gz|xz] versions first and then if no difference
+## copy all with 'abc' in name.
+
+remove_copy_script:
+  file.absent:
+    - name: {{copy_repo_check_script_file}}
+
+
+generate_copy_script:
+  file.managed:
+    - name: {{copy_repo_check_script_file}}
+    - dir_mode: 755
+    - mode: 755
+    - show_changes: False
+    - user: {{base_cfg.build_runas}}
+    - group: {{base_cfg.build_runas}}
+    - makedirs: True
+    - contents: |
+        #!/bin/sh
+
+        ## script to update built packages with originally released packages
+        ## only if they are essentially unchanged, by checking sha256sum of ABC.debian.tar.[x|g]z
+        ## since contents of ABC.debian.tar.xz only change if real changes have occured.
+
+        repo_dir=$1
+        built_dir=$2
+
+        curr_dir=$(pwd)
+        # get list of*.debian.tar.?z for repo
+        cd $repo_dir
+        repo_debtar_list=$(find . -name "*.debian.tar.?z" | cut -d '/' -f 2 | sort| uniq)
+        cd $curr_dir
+
+        cd $built_dir
+        # get list of*.debian.tar.?z for built
+        built_debtar_list=$(find . -name "*.debian.tar.?z" | cut -d '/' -f 2 | sort | uniq)
+        cd $curr_dir
+
+        ## loop thru repo list and copy repo contents if sums match
+        for idx in $repo_debtar_list
+        do
+            for bdx in $built_debtar_list
+            do
+                if [ "$idx" = "$bdx" ]; then
+                    repo_sum=$(sha256sum $repo_dir/$idx | cut -d ' ' -f 1)
+                    built_sum=$(sha256sum $built_dir/$bdx | cut -d ' ' -f 1)
+                    if [ "$repo_sum" = "$built_sum" ]; then
+                        item=$(echo $idx | cut -d '_' -f 1)
+                        copy_list=$(find $repo_dir -name "*$item*")
+                        for cpx in $copy_list
+                        do
+                            cp -f -v $cpx $built_dir/
+                        done
+                        break
+                    fi
+                fi
+            done
+        done
+
+
+execute_copy_script:
+  cmd.run:
+    - name: {{copy_repo_check_script_file}} {{base_cfg.build_salt_tmp_dir}} {{nb_srcdir}}
+    - runas: 'root'
+    - require:
+      - file: generate_copy_script
+
+
+copy_repo_deps_done:
+ cmd.run:
+    - name: echo "copied to {{nb_srcdir}} those repo products that are unchanged/"
+    - require:
+      - cmd: execute_copy_script 
+
+{% endif %}
+

--- a/file_roots/auto_setup/orch/build_platform_common.sls
+++ b/file_roots/auto_setup/orch/build_platform_common.sls
@@ -290,6 +290,16 @@ build_highstate_{{base_cfg.build_version}}_{{minion_platform}}:
         build_arch: {{tgt_build_arch}}
 
 
+copy_build_deps_repo_check_{{base_cfg.build_version}}_{{minion_platform}}:
+  salt.state:
+    - tgt: {{minion_tgt}}
+    - queue: True
+    - sls:
+      - auto_setup.copy_build_deps_check_repo
+    - require:
+      - salt: build_highstate_{{base_cfg.build_version}}_{{minion_platform}}
+
+
 sign_packages_{{base_cfg.build_version}}_{{minion_platform}}:
   salt.state:
     - tgt: {{minion_tgt}}
@@ -303,7 +313,7 @@ sign_packages_{{base_cfg.build_version}}_{{minion_platform}}:
         gpg_passphrase: {{pphrase}}
 {%- endif %}
     - require:
-      - salt: build_highstate_{{base_cfg.build_version}}_{{minion_platform}}
+      - salt: copy_build_deps_repo_check_{{base_cfg.build_version}}_{{minion_platform}}
 
 
 remove_current_{{base_cfg.build_version}}_{{minion_platform}}:
@@ -352,7 +362,7 @@ cleanup_tgt_settle_{{minion_platform}}:
     - name: cmd.run
     - tgt: {{minion_tgt}}
     - arg:
-      - sleep 120 
+      - sleep 120
     - require:
       - salt: cleanup_mount_nfs_{{minion_platform}}
 


### PR DESCRIPTION
Updated build process for Debian and Ubuntu to prefer those packages / build products which have been published on repo.saltstack.com if the dependencies for that version / latest point release are unchanged.